### PR TITLE
Merge dynwidth branch

### DIFF
--- a/src/commands/00_unset/raven-cmd-unset.adb
+++ b/src/commands/00_unset/raven-cmd-unset.adb
@@ -173,6 +173,14 @@ package body Raven.Cmd.Unset is
       Context.register_debug_level (comline.pre_command.debug_setting);
       Context.register_protocol_restriction (comline.pre_command.internet_protocol);
 
+      declare
+         term_setting  : constant String := ENV.Value ("TERM", "undefined");
+         dumb_terminal : constant Boolean := term_setting = "dumb";
+         column_width  : constant Natural := Unix.terminal_width (True, dumb_terminal);
+      begin
+         Context.register_terminal_width (column_width);
+      end;
+
       if not IsBlank (comline.pre_command.chroot_first) then
          if not Unix.change_root (USS (comline.pre_command.chroot_first)) then
             EV.emit_error ("Failed to change root directory to " &

--- a/src/commands/11_genrepo/raven-cmd-genrepo.adb
+++ b/src/commands/11_genrepo/raven-cmd-genrepo.adb
@@ -379,7 +379,7 @@ package body Raven.Cmd.Genrepo is
             Event.emit_message ("Scanning" & total_num'Img & " packages for catalog generation...");
             if total_num >= PROGRESS_MIN then
                show_info := True;
-               Event.emit_premessage ("  Progress: 0%" & LAT.CR);
+               Event.emit_premessage (" progress: 0%" & LAT.CR);
             end if;
          end if;
       end execute_scan;
@@ -391,7 +391,8 @@ package body Raven.Cmd.Genrepo is
 
          procedure print (num_image : String) is
          begin
-            Event.emit_premessage ("  Progress: " & num_image & "%" & LAT.CR);
+            Event.emit_premessage (" progress: " & num_image & "%" & LAT.CR);
+            TIO.Flush;
          end print;
       begin
          for z in Scanner_Range loop

--- a/src/commands/11_genrepo/raven-cmd-genrepo.adb
+++ b/src/commands/11_genrepo/raven-cmd-genrepo.adb
@@ -379,7 +379,7 @@ package body Raven.Cmd.Genrepo is
             Event.emit_message ("Scanning" & total_num'Img & " packages for catalog generation...");
             if total_num >= PROGRESS_MIN then
                show_info := True;
-               Event.emit_premessage ("Progress: ");
+               Event.emit_premessage ("  Progress: 0%" & LAT.CR);
             end if;
          end if;
       end execute_scan;
@@ -389,12 +389,9 @@ package body Raven.Cmd.Genrepo is
          completed : Natural := 0;
          resint    : Natural;
 
-         procedure print (num_image : String)
-         is
-            canvas : String (1 .. (num_image'Length + 1) * 2) := (others => LAT.BS);
+         procedure print (num_image : String) is
          begin
-            canvas (canvas'First .. canvas'First + num_image'Length) := num_image & '%';
-            Event.emit_premessage (canvas);
+            Event.emit_premessage ("  Progress: " & num_image & "%" & LAT.CR);
          end print;
       begin
          for z in Scanner_Range loop
@@ -498,7 +495,8 @@ package body Raven.Cmd.Genrepo is
          TIO.Close (catalog_handle);
       end if;
       if show_info then
-         Event.emit_message ("complete");
+         --  Clear progress (we're done)
+         Event.emit_message ("                   ");
       end if;
 
       return combined_well;

--- a/src/commands/11_genrepo/raven-cmd-genrepo.adb
+++ b/src/commands/11_genrepo/raven-cmd-genrepo.adb
@@ -6,6 +6,7 @@ with Ada.Direct_IO;
 with Ada.Exceptions;
 with Ada.Directories;
 with Ada.Streams.Stream_IO;
+with Ada.Characters.Latin_1;
 with GNAT.OS_Lib;
 
 with Archive.Dirent.Scan;
@@ -25,6 +26,7 @@ package body Raven.Cmd.Genrepo is
    package TIO renames Ada.Text_IO;
    package DIR renames Ada.Directories;
    package SIO renames Ada.Streams.Stream_IO;
+   package LAT renames Ada.Characters.Latin_1;
    package OSL renames GNAT.OS_Lib;
    package SCN renames Archive.Dirent.Scan;
    package UNX renames Archive.Unix;
@@ -169,19 +171,25 @@ package body Raven.Cmd.Genrepo is
       type A_Task_Queue is array (Scanner_Range) of string_crate.Vector;
       type A_Task_State is array (Scanner_Range) of Boolean;
       type A_Task_File  is array (Scanner_Range) of TIO.File_Type;
+      type A_Task_Count is array (Scanner_Range) of Natural;
       type A_Task_Product is array (Scanner_Range) of Text;
+      type progress_increments is (ten, five, one, tenth);
 
       task_queue      : A_Task_Queue;
       task_files      : A_Task_File;
       task_product    : A_Task_Product;
+      task_count      : A_Task_Count := (others => 0);
       finished_task   : A_Task_State := (others => False);
       number_scanners : Natural := Natural (number_cpus);
       total_num       : Natural := 0;
       must_wait       : Boolean := True;
       combined_well   : Boolean := True;
       fragments_good  : Boolean := True;
+      show_info       : Boolean := False;
       catalog_handle  : TIO.File_Type;
       last_worker     : Scanner_Range := 1;
+      pincrement      : progress_increments := tenth;
+      PROGRESS_MIN    : constant Natural := 100;
 
       procedure create_fragment_files is
       begin
@@ -334,6 +342,7 @@ package body Raven.Cmd.Genrepo is
                ThickUCL.drop_base_keypair (metatree, "directories");
                ThickUCL.drop_base_keypair (metatree, "scripts");
                TIO.Put_Line (task_files (lot), ThickUCL.Emitter.emit_compact_ucl (metatree));
+               task_count (lot) := task_count (lot) + 1;
 
             end scan_rvn_package;
          begin
@@ -367,9 +376,51 @@ package body Raven.Cmd.Genrepo is
       begin
          Event.emit_debug (moderate, "All tasks spawned");
          if not quiet then
-            Event.emit_message ("Scanning packages for catalog generation...");
+            Event.emit_message ("Scanning" & total_num'Img & " packages for catalog generation...");
+            if total_num >= PROGRESS_MIN then
+               show_info := True;
+               Event.emit_premessage ("Progress: ");
+            end if;
          end if;
       end execute_scan;
+
+      procedure show_progress
+      is
+         completed : Natural := 0;
+         resint    : Natural;
+
+         procedure print (num_image : String)
+         is
+            canvas : String (1 .. (num_image'Length + 1) * 2) := (others => LAT.BS);
+         begin
+            canvas (canvas'First .. canvas'First + num_image'Length) := num_image & '%';
+            Event.emit_premessage (canvas);
+         end print;
+      begin
+         for z in Scanner_Range loop
+            completed := completed + task_count (z);
+         end loop;
+         case pincrement is
+            when ten =>
+               resint := ((completed * 10) / total_num) * 10;
+            when five =>
+               resint := ((completed * 20) / total_num) * 5;
+            when one =>
+               resint := ((completed * 100) / total_num);
+            when tenth =>
+               resint := ((completed * 1000) / total_num);
+         end case;
+         case pincrement is
+            when ten | five | one =>
+               print (Strings.int2str (resint));
+            when tenth =>
+               declare
+                  raw : constant String := Strings.int2str (resint);
+               begin
+                  print (raw (raw'First .. raw'Last - 1) & '.' & raw (raw'Last));
+               end;
+         end case;
+      end show_progress;
 
    begin
       if number_scanners > Natural (Scanner_Range'Last) then
@@ -384,6 +435,13 @@ package body Raven.Cmd.Genrepo is
       if not fragments_good then
          return False;
       end if;
+      if total_num < 240 then
+         pincrement := ten;
+      elsif total_num < 800 then
+         pincrement := five;
+      elsif total_num < 4000 then
+         pincrement := one;
+      end if;
 
       execute_scan;
       while must_wait loop
@@ -394,6 +452,9 @@ package body Raven.Cmd.Genrepo is
                must_wait := True;
             end if;
          end loop;
+         if show_info then
+            show_progress;
+         end if;
       end loop;
       close_fragment_files;
 
@@ -435,6 +496,9 @@ package body Raven.Cmd.Genrepo is
 
       if TIO.Is_Open (catalog_handle) then
          TIO.Close (catalog_handle);
+      end if;
+      if show_info then
+         Event.emit_message ("complete");
       end if;
 
       return combined_well;

--- a/src/commands/11_genrepo/raven-cmd-genrepo.adb
+++ b/src/commands/11_genrepo/raven-cmd-genrepo.adb
@@ -403,20 +403,26 @@ package body Raven.Cmd.Genrepo is
             when five =>
                resint := ((completed * 20) / total_num) * 5;
             when one =>
-               resint := ((completed * 100) / total_num);
+               resint := (completed * 100) / total_num;
             when tenth =>
-               resint := ((completed * 1000) / total_num);
+               resint := ((total_num + completed) * 1000) / total_num;
          end case;
-         case pincrement is
-            when ten | five | one =>
-               print (Strings.int2str (resint));
-            when tenth =>
-               declare
-                  raw : constant String := Strings.int2str (resint);
-               begin
-                  print (raw (raw'First .. raw'Last - 1) & '.' & raw (raw'Last));
-               end;
-         end case;
+         declare
+            raw : constant String := Strings.int2str (resint);
+         begin
+            case pincrement is
+               when ten | five | one =>
+                  print (raw);
+               when tenth =>
+                  --  minimum value is "1000", 4 cols guaranteed.  always drop first column
+                  --  if completed = total num, resint = 2000
+                  if resint = 2000 then
+                     print("100.0");
+                  else
+                     print (raw (raw'First + 1 .. raw'First + 2) & '.' & raw (raw'Last));
+                  end if;
+            end case;
+         end;
       end show_progress;
 
    begin

--- a/src/configuration/raven-context.adb
+++ b/src/configuration/raven-context.adb
@@ -164,6 +164,15 @@ package body Raven.Context is
    end reveal_protocol_restriction;
 
 
+   -----------------------------
+   --  reveal_terminal_width  --
+   -----------------------------
+   function reveal_terminal_width return Natural is
+   begin
+      return context.display_width;
+   end reveal_terminal_width;
+
+
    ----------------------------
    --  register_debug_level  --
    ----------------------------
@@ -234,6 +243,15 @@ package body Raven.Context is
    begin
       context.internet_proto := setting;
    end register_protocol_restriction;
+
+
+   -------------------------------
+   --  register_terminal_width  --
+   -------------------------------
+   procedure register_terminal_width (width : Natural) is
+   begin
+      context.display_width := width;
+   end register_terminal_width;
 
 
 end Raven.Context;

--- a/src/configuration/raven-context.ads
+++ b/src/configuration/raven-context.ads
@@ -15,6 +15,7 @@ package Raven.Context is
    function reveal_cache_directory return String;
    function reveal_db_directory return String;
    function reveal_protocol_restriction return IP_support;
+   function reveal_terminal_width return Natural;
 
    procedure close_event_pipe;
    procedure close_root_directory_fd;
@@ -27,6 +28,7 @@ package Raven.Context is
    procedure register_db_directory (dir: String);
    procedure register_case_sensitivity (sensitive : Boolean);
    procedure register_protocol_restriction (setting : IP_support);
+   procedure register_terminal_width (width : Natural);
    function register_event_pipe_via_file (pipe_name : String) return Boolean;
    function register_event_pipe_via_socket (pipe_name : String) return Unix.Unix_Socket_Result;
 
@@ -44,6 +46,7 @@ private
          cachedir_fd    : Unix.File_Descriptor := Unix.not_connected;
          dbdir_fd       : Unix.File_Descriptor := Unix.not_connected;
          internet_proto : IP_support := no_restriction;
+         display_width  : Natural := 80;
       end record;
 
    context : A_context;

--- a/src/raven.ads
+++ b/src/raven.ads
@@ -7,7 +7,7 @@ package Raven is
 
    package SU renames Ada.Strings.Unbounded;
    
-   progversion    : constant String := "0.4.1";
+   progversion    : constant String := "0.4.2";
    progname       : constant String := "rvn";
    extension      : constant String := ".rvn";
    install_loc    : constant String := "/raven";

--- a/src/sundry/raven-deinstall.adb
+++ b/src/sundry/raven-deinstall.adb
@@ -592,6 +592,16 @@ package body Raven.Deinstall is
       behave_quiet   : Boolean;
       dryrun         : Boolean)
    is
+      function max_line_width return Natural
+      is
+         width : constant Natural := Context.reveal_terminal_width;
+      begin
+         if width > 100 then
+            return 100;
+         end if;
+         return width;
+      end max_line_width;
+
       --  Display format
       --   6 chars: right-padded 5 spaces counter, plus + space
       --  73 chars: display nsv + version (right just).
@@ -599,10 +609,10 @@ package body Raven.Deinstall is
       --  --------------
       --  79 chars
       --
-      --  If terminal width > 80, the second field is expanded accordingly
+      --  If terminal width > 80, the second field is expanded accordingly (up to 100 chars)
 
       counter : Natural := 0;
-      twidth  : constant Natural := Context.reveal_terminal_width;
+      twidth  : constant Natural := max_line_width;
 
       procedure display_line (Position : Purge_Order_Crate.Cursor)
       is

--- a/src/sundry/raven-deinstall.adb
+++ b/src/sundry/raven-deinstall.adb
@@ -7,6 +7,7 @@ with Lua;
 with Bourne;
 with Blake_3;
 with Raven.Event;
+with Raven.Context;
 with Raven.Strings;
 with Raven.Triggers;
 with Raven.Cmd.Unset;
@@ -597,14 +598,17 @@ package body Raven.Deinstall is
       --            If nsv too long, replace last char with *
       --  --------------
       --  79 chars
+      --
+      --  If terminal width > 80, the second field is expanded accordingly
 
       counter : Natural := 0;
+      twidth  : constant Natural := Context.reveal_terminal_width;
 
       procedure display_line (Position : Purge_Order_Crate.Cursor)
       is
          plndx     : constant Natural := Purge_Order_Crate.Element (Position);
          myrec     : Pkgtypes.A_Package renames purge_list.Element (plndx);
-         full_line : String (1 .. 79) := (others => ' ');
+         full_line : String (1 .. twidth - 1) := (others => ' ');
          max_nsv   : Natural;
       begin
          counter := counter + 1;
@@ -615,7 +619,7 @@ package body Raven.Deinstall is
             vstart : constant Natural := full_line'Last - ver'Length + 1;
          begin
             full_line (vstart .. full_line'Last) := ver;
-            max_nsv := 73 - (ver'Length + 1);
+            max_nsv := twidth - 7 - (ver'Length + 1);
             if nsv'Length > max_nsv then
                full_line (7 .. 6 + max_nsv - 1) := nsv (nsv'First .. nsv'First + max_nsv - 2);
                full_line (6 + max_nsv) := '*';

--- a/src/sundry/raven-install.adb
+++ b/src/sundry/raven-install.adb
@@ -1316,7 +1316,8 @@ package body Raven.Install is
    procedure print_next_installation (nextpkg  : Install_Order_Type;
                                       version  : String;
                                       counter  : Natural;
-                                      total    : Natural)
+                                      total    : Natural;
+                                      width    : Natural)
    is
       function progress return String is
       begin
@@ -1362,7 +1363,7 @@ package body Raven.Install is
             return;
          end if;
          declare
-            canvas : String (1 .. 75) := pad_right (msg, 75);
+            canvas : String (1 .. width) := pad_right (msg, width);
          begin
             Event.emit_premessage (canvas);
          end;
@@ -1423,6 +1424,7 @@ package body Raven.Install is
    is
       counter : Natural := 0;
       total_flatsize : Pkgtypes.Package_Size := 0;
+      term_width : constant Natural := Context.reveal_terminal_width - 5;  --  75 for 80-col term
 
       procedure increment (flatsize : Pkgtypes.Package_Size)
       is
@@ -1458,7 +1460,7 @@ package body Raven.Install is
          already_installed : constant Boolean := install_map.Contains (myrec.nsv);
       begin
          counter := counter + 1;
-         print_next_installation (myrec, version, counter, 0);
+         print_next_installation (myrec, version, counter, 0, term_width);
          case myrec.action is
             when new_install =>
                increment (cache_map.Element (myrec.nsv).flatsize);
@@ -1498,6 +1500,7 @@ package body Raven.Install is
    is
       tmp_filename  : constant String := Miscellaneous.get_temporary_filename ("install");
       total_steps   : constant Natural := Natural (queue.Length);
+      term_width    : constant Natural := Context.reveal_terminal_width - 5;  --  75 for 80-col term
       this_step     : Natural := 0;
       install_log   : TIO.File_Type;
       problem_found : Boolean := False;
@@ -1542,7 +1545,7 @@ package body Raven.Install is
 
          this_step := this_step + 1;
          if not behave_quiet then
-            print_next_installation (myrec, version, this_step, total_steps);
+            print_next_installation (myrec, version, this_step, total_steps, term_width);
          end if;
          case myrec.action is
             when reinstall | upgrade | reset_auto =>

--- a/src/sundry/raven-install.ads
+++ b/src/sundry/raven-install.ads
@@ -157,7 +157,8 @@ private
      (nextpkg  : Install_Order_Type;
       version  : String;
       counter  : Natural;
-      total    : Natural);
+      total    : Natural;
+      width    : Natural);
 
    function granted_permission_to_proceed
      (quiet : Boolean) return Boolean;

--- a/src/unix/iocontrol.c
+++ b/src/unix/iocontrol.c
@@ -1,0 +1,17 @@
+/*
+ *  SPDX-License-Identifier: ISC
+ *  Reference: /License.txt
+ */
+
+#if !defined _WIN32
+
+#include <sys/ioctl.h>
+
+unsigned short
+get_columns (void) {
+	struct winsize w;
+	ioctl(0, TIOCGWINSZ, &w);
+	return w.ws_col;
+}
+
+#endif

--- a/src/unix/raven-unix.adb
+++ b/src/unix/raven-unix.adb
@@ -321,10 +321,15 @@ package body Raven.Unix is
    ----------------------
    --  terminal_width  --
    ----------------------
-   function terminal_width (min80 : Boolean := False) return Natural
+   function terminal_width
+     (min80 : Boolean := False;
+      dumb  : Boolean := False) return Natural
    is
       res : IC.short;
    begin
+      if dumb then
+         return 132;
+      end if;
       res := c_term_columns;
       if min80 then
          case res is

--- a/src/unix/raven-unix.adb
+++ b/src/unix/raven-unix.adb
@@ -321,15 +321,22 @@ package body Raven.Unix is
    ----------------------
    --  terminal_width  --
    ----------------------
-   function terminal_width return Natural
+   function terminal_width (min80 : Boolean := False) return Natural
    is
       res : IC.short;
    begin
       res := c_term_columns;
-      case res is
-         when 0 .. IC.short'Last => return Natural (res);
-         when others => return 0;
-      end case;
+      if min80 then
+         case res is
+            when 81 .. IC.short'Last => return Natural (res);
+            when others => return 80;
+         end case;
+      else
+         case res is
+            when 0 .. IC.short'Last => return Natural (res);
+            when others => return 0;
+         end case;
+      end if;
    end terminal_width;
 
 end Raven.Unix;

--- a/src/unix/raven-unix.adb
+++ b/src/unix/raven-unix.adb
@@ -317,4 +317,19 @@ package body Raven.Unix is
       return success (result);
    end change_root;
 
+
+   ----------------------
+   --  terminal_width  --
+   ----------------------
+   function terminal_width return Natural
+   is
+      res : IC.short;
+   begin
+      res := c_term_columns;
+      case res is
+         when 0 .. IC.short'Last => return Natural (res);
+         when others => return 0;
+      end case;
+   end terminal_width;
+
 end Raven.Unix;

--- a/src/unix/raven-unix.ads
+++ b/src/unix/raven-unix.ads
@@ -154,7 +154,13 @@ package Raven.Unix is
    function change_root (dirname : String) return Boolean;
 
    --  Returns number of column of terminal
-   function terminal_width (min80 : Boolean := False) return Natural;
+   --  If "dumb", always returns 132
+   --  Otherwise:
+   --     if "min80" returns 80 if <=80
+   --     return True width
+   function terminal_width
+     (min80 : Boolean := False;
+      dumb  : Boolean := False) return Natural;
 
 private
 

--- a/src/unix/raven-unix.ads
+++ b/src/unix/raven-unix.ads
@@ -154,7 +154,7 @@ package Raven.Unix is
    function change_root (dirname : String) return Boolean;
 
    --  Returns number of column of terminal
-   function terminal_width return Natural;
+   function terminal_width (min80 : Boolean := False) return Natural;
 
 private
 

--- a/src/unix/raven-unix.ads
+++ b/src/unix/raven-unix.ads
@@ -153,6 +153,9 @@ package Raven.Unix is
    --  wrap chroot(2) from libc
    function change_root (dirname : String) return Boolean;
 
+   --  Returns number of column of terminal
+   function terminal_width return Natural;
+
 private
 
    last_errno : Integer;
@@ -226,5 +229,8 @@ private
 
    function C_chroot (dirname : IC.Strings.chars_ptr) return IC.int;
    pragma Import (C, C_chroot, "chroot");
+
+   function c_term_columns return IC.short;
+   pragma Import (C, c_term_columns, "get_columns");
 
 end Raven.Unix;


### PR DESCRIPTION
Implement features #7 and #9 
The width of window is no longer assumed to be 80 columns.
If it's greater than 80, the extra columns can be used.
However, terminal windows less than 80 columns will still get 80-column output.

Also, a progress indicator is added to the repo generation.